### PR TITLE
fix: Prevention of adding same items on multiple spontaneous clicks

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -15,6 +15,7 @@ export const Card = (props) => {
   const { authState } = useAuth();
   const navigate = useNavigate();
   const [wishlistBtnDisabled, setWishlistBtnDisabled] = useState(false);
+  const [addBtnDisabled, setAddBtnDisabled] = useState(false);
 
   const productInCart = (productId) => {
     let productExists = cart.findIndex((item) => item._id === productId);
@@ -23,7 +24,8 @@ export const Card = (props) => {
 
   const addToCartHandler = (props) => {
     if (authState.token && productInCart(props._id) === "Add to cart") {
-      addItemToCart(props);
+      setAddBtnDisabled(true);
+      addItemToCart(props, setAddBtnDisabled);
     } else if (productInCart(props._id) === "Add to cart" && !authState.token)
       navigate("/login");
     else if (productInCart(props._id) === "Go to cart" && authState.token) {
@@ -82,6 +84,7 @@ export const Card = (props) => {
         <div className="card-footer">
           <button
             className="btn btn-primary"
+            disabled={addBtnDisabled}
             onClick={() => {
               addToCartHandler(props);
             }}

--- a/src/components/Card/CartCard.jsx
+++ b/src/components/Card/CartCard.jsx
@@ -11,6 +11,7 @@ export const CartCard = (props) => {
   const { addItemToWishlist, wishlistState } = useWishlist();
   const { wishlist } = wishlistState;
   const [addBtnDisabled, setDisabled] = useState(false);
+  const [moveToWishlist, setMoveToWishlist] = useState(false);
   const { authState } = useAuth();
   const navigate = useNavigate();
 
@@ -23,7 +24,8 @@ export const CartCard = (props) => {
 
   const addToWishlistHandler = (product) => {
     if (authState.token && productInWishlist(product._id)) {
-      addItemToWishlist(product);
+      setMoveToWishlist(true);
+      addItemToWishlist(product, setMoveToWishlist);
     } else if (!authState.token && productInWishlist(product._id)) {
       navigate("/login");
     }
@@ -64,6 +66,7 @@ export const CartCard = (props) => {
           </div>
           <button
             className="btn btn-primary"
+            disabled={moveToWishlist}
             onClick={() => {
               addToWishlistHandler(props);
               deleteItemFromCart(props);

--- a/src/components/Card/WishlistCard.jsx
+++ b/src/components/Card/WishlistCard.jsx
@@ -1,5 +1,6 @@
 import "./card.css";
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
 import { useWishlist } from "../../context/wishlist-context";
 import { useAuth } from "../../context/auth-context";
 import { useCart } from "../../context/cart-context";
@@ -11,13 +12,15 @@ export const WishlistCard = (product) => {
   const { cartState, addItemToCart } = useCart();
   const { cart } = cartState;
   const navigate = useNavigate();
+  const [moveToBtnDisabled, setMoveToBtnDisabled] = useState(false);
   const productInCart = (productId) => {
     let productExists = cart.findIndex((item) => item._id === productId);
     return productExists === -1;
   };
   const addToCartHandler = (props) => {
     if (authState.token && productInCart(props._id)) {
-      addItemToCart(props);
+      setMoveToBtnDisabled(true);
+      addItemToCart(props, setMoveToBtnDisabled);
     } else if (productInCart(props._id) && !authState.token) navigate("/login");
   };
   return (
@@ -44,6 +47,7 @@ export const WishlistCard = (product) => {
         <div className="card-footer">
           <button
             className="btn btn-primary"
+            disabled={moveToBtnDisabled}
             onClick={() => {
               addToCartHandler(product);
               deleteItemFromWishlist({ _id });

--- a/src/context/cart-context.js
+++ b/src/context/cart-context.js
@@ -31,7 +31,7 @@ const CartProvider = ({ children }) => {
     };
     if (authState.token !== null) getCartItems();
   }, [authState.token]);
-  const addItemToCart = async (item) => {
+  const addItemToCart = async (item, setAddBtnDisabled) => {
     try {
       const response = await axios.post(
         "/api/user/cart",
@@ -41,8 +41,10 @@ const CartProvider = ({ children }) => {
         }
       );
       cartDispatch({ type: ADD_TO_CART, payload: response.data.cart });
+      setAddBtnDisabled(false);
     } catch (err) {
       alert(err);
+      setAddBtnDisabled(false);
     }
   };
   const updateProductQty = async (_id, actionType, setBtnDisabled) => {

--- a/src/context/wishlist-context.js
+++ b/src/context/wishlist-context.js
@@ -20,7 +20,7 @@ const WishlistProvider = ({ children }) => {
   useEffect(() => {
     const getWishlistItems = async () => {
       try {
-        const response = await axios.get("/api/user/wishlistt", {
+        const response = await axios.get("/api/user/wishlist", {
           headers: {
             authorization: authState.token,
           },


### PR DESCRIPTION
Prevention of adding same items on multiple spontaneous clicks - 
Fixes done:
- In products, if add to cart is clicked multiple times spontaneously, due to delay in server response, same item was getting added to cart
- In cart page, move to wishlist button, same behviour fix
- In wishlist page, move to cart button, same behaviour fix